### PR TITLE
add config "access_on_start" that access list("/") on start is optional.

### DIFF
--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -18,6 +18,7 @@ path /hdfs/path/file.%Y%m%d.log
     assert_equal '%Y%m%d', d.instance.time_slice_format
     assert_equal false, d.instance.httpfs
     assert_nil d.instance.username
+    assert_equal true, d.instance.access_on_start
     
     assert_equal true, d.instance.output_include_time
     assert_equal true, d.instance.output_include_tag


### PR DESCRIPTION
1. configure forest + webhdfs as follow

```
<match AAA.**>
    type forest
    subtype webhdfs
    remove_prefix AAA
    <template>
      host MY-NAMENODE-HOST
      port 50070
      username hdfs
      time_slice_format %Y%m%d%H%M
      time_slice_wait 30s
      output_include_time false
      output_include_tag false
      output_data_type attr:message
      path /PATH/TO/${tag}/%Y-%m-%d/%H-${hostname}-12345.log
      buffer_type file
      buffer_path /PATH/TO/buffer/12345/${tag}
      flush_at_shutdown true
    </template>
</match>
```
1. Stop namenode
2. Start Fluentd
3. Send LOG (Tag = "AAA.*")
4. Raised above error and created a thread every failed.
   And log is lost or duplicate.

```
webdhfs check request failed!
```

```
# pstree -u td-agent
ruby───179*[{ruby}]
```

I agree to check a list("/") on start method, when fluentd boot sequence.
But, use with forest-plugin is unhappy.

I propse that change list("/") check to optional. (default configure is ON)

---

Forest + WebHDFS のプラグインを組み合わせた場合、
NameNodeが落ちている時(list("/")が失敗する時)にForest-Pluginが動的にwebhdfs-pluginの設定を作ると
ログの喪失やmatchが複数生成されて(?)ログが何度も重複して書き込まれたりという現象が発生します。
webhdfsのstart時のチェックをオプショナルにしてデフォルトはいままでのままチェックするというふうにしたいです。
