### PR TITLE
add an append option

### DIFF
--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -64,5 +64,13 @@ path /hdfs/path/file.%Y%m%d.%H%M.log
     assert_equal '/hdfs/path/file.%Y%m%d.%H%M.log', d.instance.path
     assert_equal '%Y%m%d%H%M', d.instance.time_slice_format
     assert_equal '/hdfs/path/file.20120718.1503.log', d.instance.path_format('201207181503')
+
+    assert_raise Fluent::ConfigError do
+      d = create_driver %[
+            namenode server.local:14000
+            path /hdfs/path/file.%Y%m%d.%H%M.log
+            append false
+          ]
+    end
   end
 end


### PR DESCRIPTION
The problem is that an append method of WebHDFS is not atomic. In more
detail, if a datanode which you are communicating via a append method
shutdown for some reason, the file which you have been writing will
remain on HDFS containing incomplete contents, and there is no simple
way to know how much contents was written.

However, Fluentd will retry to write whole contents in a paticular chunk
when emit transaction fail because of a datanode failure.

Consequently, a duplication of content will occurs unexpectedly.

To avoid this problem, set an append option to false.
When append is set to false, flunet-plugin-webhdfs write each chunk
to indivisual file on HDFS, and a file name will not change through retries.

This patch also provides ${chunk_id} placeholder. This placeholder is availabale
for a path option and replaced with chunk#unique_id in WebHDFSOutput#write method.
