### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-webhdfs
+# fluent-plugin-webhdfs, a plugin for [Fluentd](http://fluentd.org)
 
 Fluentd output plugin to write data into Hadoop HDFS over WebHDFS/HttpFs.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
