### PR TITLE
Update bundler on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,7 @@ branches:
   only:
     - master
 
+before_install:
+  - gem update bundler
+
 script: bundle exec rake test


### PR DESCRIPTION
This fixes following error on TravisCI:

    NoMethodError: undefined method `spec' for nil:NilClass