### PR TITLE
Add bzip2 support

### DIFF
--- a/fluent-plugin-webhdfs.gemspec
+++ b/fluent-plugin-webhdfs.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
   gem.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
   gem.add_runtime_dependency "webhdfs", '>= 0.6.0'
+  gem.add_runtime_dependency "bzip2-ffi"
 end

--- a/lib/fluent/plugin/out_webhdfs.rb
+++ b/lib/fluent/plugin/out_webhdfs.rb
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+require 'tempfile'
+
 require 'fluent/mixin/config_placeholders'
 require 'fluent/mixin/plaintextformatter'
 
@@ -271,7 +273,6 @@ class Fluent::WebHDFSOutput < Fluent::TimeSlicedOutput
     case @compress
     when 'gzip'
       require 'zlib'
-      require 'tempfile'
       tmp = Tempfile.new("webhdfs-")
       begin
         w = Zlib::GzipWriter.new(tmp)

--- a/lib/fluent/plugin/out_webhdfs.rb
+++ b/lib/fluent/plugin/out_webhdfs.rb
@@ -278,8 +278,7 @@ class Fluent::WebHDFSOutput < Fluent::TimeSlicedOutput
         w = Zlib::GzipWriter.new(tmp)
         chunk.write_to(w)
         w.close
-        tmp.close
-        tmp.open
+        tmp.rewind
         yield tmp
       ensure
         tmp.close(true) rescue nil


### PR DESCRIPTION
This is based on fluent/fluent-plugin-webhdfs#25.
But I use bzip2-ffi instead of bzip2-ruby.
Because bzip2-ruby does not work at all, on the other hand bzip2-ffi works well.

This PR does not include lzo compression support because lzoruby `LZO.compress` cannot accept IO like object.

9b556b2 includes core changes for adding bzip2 compression support, almost changes are cosmetic changes related to tests.