### PR TITLE
Use `generate_chunk` like method instead of chunk related class

### DIFF
--- a/test/plugin/test_compressor.rb
+++ b/test/plugin/test_compressor.rb
@@ -4,8 +4,19 @@ require "snappy"
 
 class CompressorTest < Test::Unit::TestCase
   class Snappy < self
+
+    CONFIG = %[
+      host namenode.local
+      path /hdfs/path/file.%Y%m%d.log
+    ]
+
     def setup
+      Fluent::Test.setup
       @compressor = Fluent::WebHDFSOutput::SnappyCompressor.new
+    end
+
+    def create_driver(conf=CONFIG,tag='test')
+      Fluent::Test::OutputTestDriver.new(Fluent::WebHDFSOutput, tag).configure(conf)
     end
 
     def test_ext
@@ -13,8 +24,21 @@ class CompressorTest < Test::Unit::TestCase
     end
 
     def test_compress
-      chunk = Fluent::MemoryBufferChunk.new("test")
-      chunk << "hello snappy\n" * 32 * 1024
+      d = create_driver
+      if d.instance.respond_to?(:buffer)
+        buffer = d.instance.buffer
+      else
+        buffer = d.instance.instance_variable_get(:@buffer)
+      end
+
+      if buffer.respond_to?(:generate_chunk)
+        chunk = buffer.generate_chunk("test")
+        chunk.concat("hello snappy\n" * 32 * 1024, 1)
+      else
+        chunk = buffer.new_chunk("test")
+        chunk << "hello snappy\n" * 32 * 1024
+      end
+
       io = Tempfile.new("snappy-")
       @compressor.compress(chunk, io)
       io.open


### PR DESCRIPTION
But this test fails with Fluentd v0.14.0.rc.3.
See https://github.com/fluent/fluentd/issues/995