### PR TITLE
Enable format/inject plugin helper for Fluentd v0.14

### DIFF
--- a/fluent-plugin-webhdfs.gemspec
+++ b/fluent-plugin-webhdfs.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-webhdfs"
-  gem.version       = "0.5.3"
+  gem.version       = "0.6.0rc1"
   gem.authors       = ["TAGOMORI Satoshi"]
   gem.email         = ["tagomoris@gmail.com"]
   gem.summary       = %q{Fluentd plugin to write data on HDFS over WebHDFS, with flexible formatting}
@@ -20,9 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit-rr"
   gem.add_development_dependency "appraisal"
   gem.add_development_dependency "snappy", '>= 0.0.13'
-  gem.add_runtime_dependency "fluentd", '>= 0.14.2'
-  gem.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
-  gem.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
+  gem.add_runtime_dependency "fluentd", '>= 0.14.4'
   gem.add_runtime_dependency "webhdfs", '>= 0.6.0'
   gem.add_runtime_dependency "bzip2-ffi"
 end

--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -1,8 +1,11 @@
 require 'helper'
 
 class WebHDFSOutputTest < Test::Unit::TestCase
-  CONFIG = config_element(
+  CONFIG_DEFAULT = config_element("match", "", {"host" => "namenode.local", "path" => "/hdfs/path/file.%Y%m%d.log"})
+
+  CONFIG_COMPAT = config_element(
     "ROOT", "", {
+      "output_data_type" => "",
       "host" => "namenode.local",
       "path" => "/hdfs/path/file.%Y%m%d.log"
     })
@@ -11,13 +14,15 @@ class WebHDFSOutputTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
-  def create_driver(conf = CONFIG)
+  def create_driver(conf)
     Fluent::Test::Driver::Output.new(Fluent::Plugin::WebHDFSOutput).configure(conf)
   end
 
-  sub_test_case "flat configuration" do
-    def test_default
-      d = create_driver
+  sub_test_case "default configuration" do
+    test 'configured with standard out_file format with specified hdfs info' do
+      d = create_driver(CONFIG_DEFAULT)
+      assert_true d.instance.instance_eval{ @using_formatter_config }
+
       assert_equal 'namenode.local', d.instance.instance_eval{ @namenode_host }
       assert_equal 50070, d.instance.instance_eval{ @namenode_port }
       assert_equal '/hdfs/path/file.%Y%m%d.log', d.instance.path
@@ -25,13 +30,38 @@ class WebHDFSOutputTest < Test::Unit::TestCase
       assert_nil d.instance.username
       assert_equal false, d.instance.ignore_start_check_error
 
-      assert_equal true, d.instance.output_include_time
-      assert_equal true, d.instance.output_include_tag
-      assert_equal 'json', d.instance.output_data_type
+      assert_equal 'Fluent::Plugin::OutFileFormatter', d.instance.formatter.class.to_s
+      assert_equal true, d.instance.end_with_newline
+
+      # deprecated params
+      assert_nil d.instance.instance_eval{ @output_include_time }
+      assert_nil d.instance.instance_eval{ @output_include_tag }
       assert_nil d.instance.remove_prefix
-      assert_equal 'TAB', d.instance.field_separator
-      assert_equal true, d.instance.add_newline
-      assert_equal 'tag_missing', d.instance.default_tag
+      assert_nil d.instance.instance_eval{ @header_separator }
+      assert_nil d.instance.default_tag
+    end
+  end
+
+  sub_test_case "flat configuration" do
+    def test_default_for_traditional_config
+      d = create_driver(CONFIG_COMPAT)
+      assert_false d.instance.instance_eval{ @using_formatter_config }
+
+      assert_equal 'namenode.local', d.instance.instance_eval{ @namenode_host }
+      assert_equal 50070, d.instance.instance_eval{ @namenode_port }
+      assert_equal '/hdfs/path/file.%Y%m%d.log', d.instance.path
+      assert_equal false, d.instance.httpfs
+      assert_nil d.instance.username
+      assert_equal false, d.instance.ignore_start_check_error
+
+      assert_equal 'Fluent::Plugin::JSONFormatter', d.instance.formatter.class.to_s
+      assert_equal true, d.instance.end_with_newline
+
+      assert_equal true, d.instance.instance_eval{ @output_include_time }
+      assert_equal true, d.instance.instance_eval{ @output_include_tag }
+      assert_nil d.instance.instance_eval{ @remove_prefix }
+      assert_equal "\t", d.instance.instance_eval{ @header_separator }
+      assert_equal 'tag_missing', d.instance.instance_eval{ @default_tag }
     end
 
     def test_httpfs
@@ -72,10 +102,10 @@ class WebHDFSOutputTest < Test::Unit::TestCase
       assert_equal true, d.instance.kerberos
     end
 
-    data(gzip: ['gzip', Fluent::Plugin::WebHDFSOutput::GzipCompressor],
-         bzip2: ['bzip2', Fluent::Plugin::WebHDFSOutput::Bzip2Compressor],
-         snappy: ['snappy', Fluent::Plugin::WebHDFSOutput::SnappyCompressor],
-         lzo: ['lzo_command', Fluent::Plugin::WebHDFSOutput::LZOCommandCompressor])
+    data(gzip: [:gzip, Fluent::Plugin::WebHDFSOutput::GzipCompressor],
+         bzip2: [:bzip2, Fluent::Plugin::WebHDFSOutput::Bzip2Compressor],
+         snappy: [:snappy, Fluent::Plugin::WebHDFSOutput::SnappyCompressor],
+         lzo: [:lzo_command, Fluent::Plugin::WebHDFSOutput::LZOCommandCompressor])
     def test_compress(data)
       compress_type, compressor_class = data
       begin
@@ -96,7 +126,7 @@ class WebHDFSOutputTest < Test::Unit::TestCase
       assert_equal compressor_class, d.instance.compressor.class
     end
 
-    def test_placeholders
+    def test_placeholders_old_style
       conf = config_element(
         "ROOT", "", {
           "hostname" => "testing.node.local",
@@ -159,6 +189,55 @@ class WebHDFSOutputTest < Test::Unit::TestCase
       chunk = d.instance.buffer.generate_chunk(metadata)
       assert_equal 1, d.instance.buffer_config.timekey
       assert_equal "/hdfs/path/file.20120718.log", d.instance.generate_path(chunk)
+    end
+  end
+
+  sub_test_case "using format subsection" do
+    test "blank format means default format 'out_file' with UTC timezone" do
+      format_section = config_element("format", "", {}, [])
+      conf = config_element("match", "", {"host" => "namenode.local", "path" => "/hdfs/path/file.%Y%m%d%H.log"}, [format_section])
+      d = create_driver(conf)
+      time = event_time("2017-01-24 13:10:30 -0700")
+      line = d.instance.format("test.now", time, {"message" => "yay", "name" => "tagomoris"})
+      assert_equal "2017-01-24T20:10:30Z\ttest.now\t{\"message\":\"yay\",\"name\":\"tagomoris\"}\n", line
+    end
+
+    test "specifying timezone works well in format section" do
+      format_section = config_element("format", "", {"timezone" => "+0100"}, [])
+      conf = config_element("match", "", {"host" => "namenode.local", "path" => "/hdfs/path/file.%Y%m%d%H.log"}, [format_section])
+      d = create_driver(conf)
+      time = event_time("2017-01-24 13:10:30 -0700")
+      line = d.instance.format("test.now", time, {"message" => "yay", "name" => "tagomoris"})
+      assert_equal "2017-01-24T21:10:30+01:00\ttest.now\t{\"message\":\"yay\",\"name\":\"tagomoris\"}\n", line
+    end
+
+    test "specifying formatter type LTSV for records, without tag and timezone" do
+      format_section = config_element("format", "", {"@type" => "ltsv"}, [])
+      conf = config_element("match", "", {"host" => "namenode.local", "path" => "/hdfs/path/file.%Y%m%d%H.log"}, [format_section])
+      d = create_driver(conf)
+      time = event_time("2017-01-24 13:10:30 -0700")
+      line = d.instance.format("test.now", time, {"message" => "yay", "name" => "tagomoris"})
+      assert_equal "message:yay\tname:tagomoris\n", line
+    end
+
+    test "specifying formatter type LTSV for records, with inject section to insert tag and time" do
+      inject_section = config_element("inject", "", {"tag_key" => "tag", "time_key" => "time", "time_type" => "string", "localtime" => "false"})
+      format_section = config_element("format", "", {"@type" => "ltsv"}, [])
+      conf = config_element("match", "", {"host" => "namenode.local", "path" => "/hdfs/path/file.%Y%m%d%H.log"}, [inject_section, format_section])
+      d = create_driver(conf)
+      time = event_time("2017-01-24 13:10:30 -0700")
+      line = d.instance.format("test.now", time, {"message" => "yay", "name" => "tagomoris"})
+      assert_equal "message:yay\tname:tagomoris\ttag:test.now\ttime:2017-01-24T20:10:30Z\n", line
+    end
+  end
+
+  sub_test_case "using older configuration" do
+    test "output_data_type json is same with out_file with UTC timezone" do
+      conf = config_element("match", "", {"host" => "namenode.local", "path" => "/hdfs/path/file.%Y%m%d%H.log", "output_data_type" => "json"}, [])
+      d = create_driver(conf)
+      time = event_time("2017-01-24 13:10:30 -0700")
+      line = d.instance.format("test.now", time, {"message" => "yay", "name" => "tagomoris"})
+      assert_equal "2017-01-24T20:10:30Z\ttest.now\t{\"message\":\"yay\",\"name\":\"tagomoris\"}\n", line
     end
   end
 end


### PR DESCRIPTION
Fixes #48.

This change does:
* remove config-placehodler and plaintextformatter mixins
* enable format/inject plugin helper to control formatting in v0.14 standard way

This plugin will be ready for Fluentd v0.14 after merging this patch.