### PR TITLE
Fixed wrong method name

### DIFF
--- a/lib/fluent/plugin/out_webhdfs.rb
+++ b/lib/fluent/plugin/out_webhdfs.rb
@@ -303,7 +303,7 @@ class Fluent::Plugin::WebHDFSOutput < Fluent::Plugin::Output
     hdfs_path = if @append
                   extract_placeholders(@path, chunk.metadata)
                 else
-                  extract_placeholders(@path, chunk.metadata).gsub(CHUNK_ID_PLACE_HOLDER, dump_unique_id(chunk.unique_id))
+                  extract_placeholders(@path, chunk.metadata).gsub(CHUNK_ID_PLACE_HOLDER, dump_unique_id_hex(chunk.unique_id))
                 end
     hdfs_path = "#{hdfs_path}#{@compressor.ext}"
     if @replace_random_uuid

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -26,6 +26,7 @@ unless ENV.has_key?('VERBOSE')
 end
 
 include Fluent::Test::Helpers
+include Fluent::UniqueId::Mixin
 
 require 'fluent/plugin/out_webhdfs'
 

--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -154,6 +154,20 @@ class WebHDFSOutputTest < Test::Unit::TestCase
       assert_equal expected, d.instance.generate_path(chunk)
     end
 
+    data(path: "/hdfs/path/file.${chunk_id}.log")
+    test "generate_path without append" do |path|
+      conf = config_element(
+        "ROOT", "", {
+          "namenode" => "server.local:14000",
+          "path" => path,
+          "append" => false
+        })
+      d = create_driver(conf)
+      metadata = d.instance.metadata("test", nil, {})
+      chunk = d.instance.buffer.generate_chunk(metadata)
+      assert_equal "/hdfs/path/file.#{dump_unique_id_hex(chunk.unique_id)}.log", d.instance.generate_path(chunk)
+    end
+
     data(path: { "append" => false },
          ssl: { "ssl" => true, "ssl_verify_mode" => "invalid" },
          compress: { "compress" => "invalid" })


### PR DESCRIPTION
Hi, fluent-plugin-webhdfs team.
I noticed that an exception is occurred if `append no` option is specified like this:

```
<match access.**>
  @type webhdfs
  host namenode.my.cluster.local
  port 50070

  append no
  path   "/log/access/%Y%m%d/#{Socket.gethostname}.${chunk_id}.log"
</match>
```

This is a log message of the error.

```
2017-01-30 23:27:50 +0900 [warn]: failed to flush the buffer. retry_time=0
next_retry_seconds=2017-01-30 23:27:50 +0900 chunk="547509e9981167420dfd99ce89c6c7d9"
error_class=NoMethodError error="undefined method `dump_unique_id' for
#<Fluent::Plugin::WebHDFSOutput:007fe11293fc38>
```

In my environment this patch works well. Could anyone review and release this?