### PR TITLE
 Fix gzip close IOError issue

### DIFF
--- a/lib/fluent/plugin/webhdfs_compressor_gzip.rb
+++ b/lib/fluent/plugin/webhdfs_compressor_gzip.rb
@@ -14,7 +14,7 @@ module Fluent::Plugin
       def compress(chunk, tmp)
         w = Zlib::GzipWriter.new(tmp)
         chunk.write_to(w)
-        w.close
+        w.finish
       end
     end
   end

--- a/test/plugin/test_gzip_compressor.rb
+++ b/test/plugin/test_gzip_compressor.rb
@@ -1,0 +1,57 @@
+require "helper"
+require "fluent/plugin/buf_memory"
+begin
+  require "zlib"
+rescue LoadError
+end
+
+class GzipCompressorTest < Test::Unit::TestCase
+  class Gzip < self
+
+    CONFIG = %[
+      host namenode.local
+      path /hdfs/path/file.%Y%m%d.log
+    ]
+
+    def setup
+      omit unless Object.const_defined?(:Zlib)
+      Fluent::Test.setup
+      @compressor = Fluent::Plugin::WebHDFSOutput::GzipCompressor.new
+    end
+
+    def create_driver(conf = CONFIG)
+      Fluent::Test::Driver::Output.new(Fluent::Plugin::WebHDFSOutput).configure(conf)
+    end
+
+    def test_ext
+      assert_equal(".gz", @compressor.ext)
+    end
+
+    def test_compress
+      d = create_driver
+      if d.instance.respond_to?(:buffer)
+        buffer = d.instance.buffer
+      else
+        buffer = d.instance.instance_variable_get(:@buffer)
+      end
+
+      if buffer.respond_to?(:generate_chunk)
+        chunk = buffer.generate_chunk("test")
+        chunk.concat("hello gzip\n" * 32 * 1024, 1)
+      else
+        chunk = buffer.new_chunk("test")
+        chunk << "hello gzip\n" * 32 * 1024
+      end
+
+      io = Tempfile.new("gzip-")
+      @compressor.compress(chunk, io)
+      assert !io.closed?
+      chunk_bytesize = chunk.respond_to?(:bytesize) ? chunk.bytesize : chunk.size
+      assert(chunk_bytesize > io.read.bytesize)
+      io.rewind
+      reader = Zlib::GzipReader.new(io)
+      assert_equal(chunk.read, reader.read)
+      io.close
+    end
+  end
+end


### PR DESCRIPTION
TD-agent crashed when compress option is gzip.  
And remove the compress option(text mode) is works.

### Error MSG

error_class=IOError error="closed stream"


### ENV
1. ubuntu 14.04
2. webhdfs
3. td-agent --version: 0.12.20
4. gems
fluent-plugin-webhdfs (0.5.1)
webhdfs (0.8.0)

### /etc/td-agent/td-agent.conf
```
<match test.worker>
  type copy
  <store>
    type    forest
    subtype webhdfs
    <template>
      buffer_type        file
      buffer_path        /var/log/td-agent/buffer/hdfs-stream-no-append.${tag}.buffer
      flush_at_shutdown  true
      namenode           nn1.test.io:50070
      standby_namenode   nn2.test.io:50070
      path               /stream/${tag}/%Y%m%d/%H/${hostname}.${chunk_id}.log
      compress           gzip
      kerberos           true
      append             false
      flush_interval     10m
    </template>
  </store>
</match>
```
The cause is this
- https://github.com/fluent/fluent-plugin-webhdfs/blob/master/lib/fluent/plugin/out_webhdfs.rb#L323-L325

TMP file IO is closed before yield at https://github.com/fluent/fluent-plugin-webhdfs/blob/master/lib/fluent/plugin/webhdfs_compressor_gzip.rb#L17

So I changed
- https://github.com/fluent/fluent-plugin-webhdfs/blob/master/lib/fluent/plugin/webhdfs_compressor_gzip.rb#L17
from w.close to w.finish.

finish function is never calls the close method of the associated IO Object. 

After this patch, TD-agent is going well. 
