### PR TITLE
Remove bzip2-ffi from runtime dependency

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,10 +1,12 @@
 appraise "fluentd v0.12" do
   gem "fluentd", "~>0.12.0"
   gem "snappy"
+  gem "bzip2-ffi"
 end
 
 appraise "fluentd v0.14" do
   gem "fluentd", "~>0.14.0"
   gem "snappy"
+  gem "bzip2-ffi"
 end
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ If you want to compress data before storing it:
     </match>
 
 Note that if you set `compress gzip`, then the suffix `.gz` will be added to path (or `.bz2`, `sz`, `.lzo`).
-Note that you have to install snappy gem if you want to  set `compress snappy`.
+Note that you have to install additional gem for several compress algorithms:
+
+- snappy: install snappy gem
+- bzip2: install bzip2-ffi gem
 
 ### Namenode HA / Auto retry for WebHDFS known errors
 

--- a/fluent-plugin-webhdfs.gemspec
+++ b/fluent-plugin-webhdfs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit-rr"
   gem.add_development_dependency "appraisal"
   gem.add_development_dependency "snappy", '>= 0.0.13'
+  gem.add_development_dependency "bzip2-ffi"
   gem.add_runtime_dependency "fluentd", '>= 0.14.4'
   gem.add_runtime_dependency "webhdfs", '>= 0.6.0'
-  gem.add_runtime_dependency "bzip2-ffi"
 end

--- a/lib/fluent/plugin/webhdfs_compressor_bzip2.rb
+++ b/lib/fluent/plugin/webhdfs_compressor_bzip2.rb
@@ -4,7 +4,11 @@ module Fluent::Plugin
       WebHDFSOutput.register_compressor('bzip2', self)
 
       def initialize(options = {})
-        require "bzip2/ffi"
+        begin
+          require "bzip2/ffi"
+        rescue LoadError
+          raise Fluent::ConfigError, "Install bzip2-ffi before use bzip2 compressor"
+        end
       end
 
       def ext


### PR DESCRIPTION
Almost users don't use bzip2 so it should be optional.

@tagomoris Could you check this?