### PR TITLE
Remove incorrect warning about ${chunk_id} placeholder in path

### DIFF
--- a/lib/fluent/plugin/out_webhdfs.rb
+++ b/lib/fluent/plugin/out_webhdfs.rb
@@ -310,7 +310,7 @@ class Fluent::Plugin::WebHDFSOutput < Fluent::Plugin::Output
     hdfs_path = if @append
                   extract_placeholders(@path, chunk.metadata)
                 else
-                  extract_placeholders(@path, chunk.metadata).gsub(CHUNK_ID_PLACE_HOLDER, dump_unique_id_hex(chunk.unique_id))
+                  extract_placeholders(@path.gsub(CHUNK_ID_PLACE_HOLDER, dump_unique_id_hex(chunk.unique_id)), chunk.metadata)
                 end
     hdfs_path = "#{hdfs_path}#{@compressor.ext}"
     if @replace_random_uuid

--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -168,6 +168,7 @@ class WebHDFSOutputTest < Test::Unit::TestCase
       metadata = d.instance.metadata("test", nil, {})
       chunk = d.instance.buffer.generate_chunk(metadata)
       assert_equal "/hdfs/path/file.#{dump_unique_id_hex(chunk.unique_id)}.log", d.instance.generate_path(chunk)
+      assert_empty d.instance.log.out.logs
     end
 
     data(path: { "append" => false },


### PR DESCRIPTION
I found a bug that occurred when specify the $ {chunk_id} parameter.

e.g. Start td-agent with the following match directive.
```
<match access.**>
  @type webhdfs
  namenode xx.xx.xx.xx:50070
  standby_namenode xx.xx.xx.xx:50070
  append false
  path "/data/access.%Y%m%d_%H.${chunk_id}.log"
  <buffer>
    @type file
    path /var/log/td-agent/buffer/webhdfs
    timekey 1h
    timekey_wait 10m # 10mins delay for flush
    timekey_zone +0900
  </buffer>
  <inject>
    tag_key tag
    time_key time
    time_type string
    timezone +0900
  </inject>
</match>
```

The following warn log is output.
```
2017-07-24 18:04:30 +0900 [warn]: #0 chunk key placeholder '' not replaced. templace:/data/access.%Y%m%d_%H.${chunk_id}.log
```

But the access log with $ {chunk_id} replaced is sent to HDFS
```
$ hdfs dfs -ls /data
/data/access.20170724_17.55531b5738962d9dee86ebba350494a0.log
```

Execution environment
- CentOS 6.6
- td-agent v0.14.18
- fluent-plugin-webhdfs v1.2.1

I think that it is caused by replacing the $ {chunk_id} parameter after passing path to `extract_placeholders` function of fluentd's Output Plugin.
https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/output.rb#L702-L704

So, I fix logic to replace ${chunk_id} parameter.