### PR TITLE
Pass chunk directly instead of chunk.metadata

### DIFF
--- a/fluent-plugin-webhdfs.gemspec
+++ b/fluent-plugin-webhdfs.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "appraisal"
   gem.add_development_dependency "snappy", '>= 0.0.13'
   gem.add_development_dependency "bzip2-ffi"
-  gem.add_runtime_dependency "fluentd", '>= 0.14.4'
+  gem.add_runtime_dependency "fluentd", '>= 0.14.22'
   gem.add_runtime_dependency "webhdfs", '>= 0.6.0'
 end

--- a/lib/fluent/plugin/out_webhdfs.rb
+++ b/lib/fluent/plugin/out_webhdfs.rb
@@ -315,9 +315,9 @@ class Fluent::Plugin::WebHDFSOutput < Fluent::Plugin::Output
 
   def generate_path(chunk)
     hdfs_path = if @append
-                  extract_placeholders(@path, chunk.metadata)
+                  extract_placeholders(@path, chunk)
                 else
-                  extract_placeholders(@path.gsub(CHUNK_ID_PLACE_HOLDER, dump_unique_id_hex(chunk.unique_id)), chunk.metadata)
+                  extract_placeholders(@path.gsub(CHUNK_ID_PLACE_HOLDER, dump_unique_id_hex(chunk.unique_id)), chunk)
                 end
     hdfs_path = "#{hdfs_path}#{@compressor.ext}"
     if @replace_random_uuid


### PR DESCRIPTION
extract_placeholders should be passed `chunk` instance directly instead of `chunk.metadata`.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>