### PR TITLE
Modify Snappy Usage.

### DIFF
--- a/lib/fluent/plugin/webhdfs_compressor_snappy.rb
+++ b/lib/fluent/plugin/webhdfs_compressor_snappy.rb
@@ -16,9 +16,10 @@ module Fluent::Plugin
       end
 
       def compress(chunk, tmp)
-        w = Snappy::Writer.new(tmp)
-        chunk.write_to(w)
-        w.close
+        Snappy::Writer.new(tmp) do |w|
+          w << chunk.read
+          w.flush
+        end
       end
     end
   end


### PR DESCRIPTION
I modify Snappy Usage.
correct usage:
```
def compress(chunk, tmp)
        Snappy::Writer.new(tmp) do |w|
          w << chunk.read
          w.flush
        end
end
```

Before modify, ([issue73](https://github.com/fluent/fluent-plugin-webhdfs/issues/73)) occurred TypeError "no implicit conversion from nil to integer". After modify, It was confirmed that the typeError did not occur anymore, and I can see that it is stored in hdfs successfully.

![Screenshot from 2020-06-01 14-42-34](https://user-images.githubusercontent.com/22383120/83379323-2712ca00-a416-11ea-882e-a75faa55f51f.png)

In addition, I checked that the snappy file was read normally through `hadoop fs -text /path/snappy` , and also checked in .pig script.