### PR TITLE
explicit file extensions in HDFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ Note that you have to install additional gem for several compress algorithms:
 
 Note that zstd will require installation of the libzstd native library. See the [zstandard-ruby](https://github.com/msievers/zstandard-ruby#examples-for-installing-libzstd) repo for infomration on the required packages for your operating system.
 
+If you want to explicitly specify file extensions in HDFS (override default compressor extensions):
+
+    <match access.**>
+      @type webhdfs
+      host namenode.your.cluster.local
+      port 50070
+      path /path/on/hdfs/access.log.%Y%m%d_%H
+      compress snappy
+      extension ".snappy"
+    </match>
+
+With this configuration paths in HDFS will be like `/path/on/hdfs/access.log.20201003_12.snappy`.
+This one may be useful when (for example) you need to use snappy codec but `.sz` files are not recognized as snappy files in HDFS.
+
 ### Namenode HA / Auto retry for WebHDFS known errors
 
 `fluent-plugin-webhdfs` (v0.2.0 or later) accepts 2 namenodes for Namenode HA (active/standby). Use `standby_namenode` like this:

--- a/lib/fluent/plugin/out_webhdfs.rb
+++ b/lib/fluent/plugin/out_webhdfs.rb
@@ -71,6 +71,9 @@ class Fluent::Plugin::WebHDFSOutput < Fluent::Plugin::Output
   desc "Compress method (#{SUPPORTED_COMPRESS.join(',')})"
   config_param :compress, :enum, list: SUPPORTED_COMPRESS, default: :text
 
+  desc 'HDFS file extensions (overrides default compressor extensions)'
+  config_param :extension, :string, default: nil
+
   config_param :remove_prefix, :string, default: nil, deprecated: "use @label for routing"
   config_param :default_tag, :string, default: nil, deprecated: "use @label for routing"
   config_param :null_value, :string, default: nil, deprecated: "use filter plugins to convert null values into any specified string"
@@ -319,7 +322,8 @@ class Fluent::Plugin::WebHDFSOutput < Fluent::Plugin::Output
                 else
                   extract_placeholders(@path.gsub(CHUNK_ID_PLACE_HOLDER, dump_unique_id_hex(chunk.unique_id)), chunk)
                 end
-    hdfs_path = "#{hdfs_path}#{@compressor.ext}"
+    hdfs_ext = @extension || @compressor.ext
+    hdfs_path = "#{hdfs_path}#{hdfs_ext}"
     if @replace_random_uuid
       uuid_random = SecureRandom.uuid
       hdfs_path = hdfs_path.gsub('%{uuid}', uuid_random).gsub('%{uuid_flush}', uuid_random)

--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -126,6 +126,26 @@ class WebHDFSOutputTest < Test::Unit::TestCase
       assert_equal '/hdfs/path/file.%Y%m%d.%H%M.log', d.instance.path
       assert_equal compress_type, d.instance.compress
       assert_equal compressor_class, d.instance.compressor.class
+
+      time = event_time("2020-10-03 15:07:00 +0300")
+      metadata = d.instance.metadata("test", time, {})
+      chunk = d.instance.buffer.generate_chunk(metadata)
+      assert_equal "/hdfs/path/file.20201003.1507.log#{d.instance.compressor.ext}", d.instance.generate_path(chunk)
+    end
+
+    def test_explicit_extensions
+      conf = config_element(
+        "ROOT", "", {
+          "host" => "namenode.local",
+          "path" => "/hdfs/path/file.%Y%m%d.log",
+          "compress" => "snappy",
+          "extension" => ".snappy"
+        })
+      d = create_driver(conf)
+      time = event_time("2020-10-07 15:15:00 +0300")
+      metadata = d.instance.metadata("test", time, {})
+      chunk = d.instance.buffer.generate_chunk(metadata)
+      assert_equal "/hdfs/path/file.20201007.log.snappy", d.instance.generate_path(chunk)
     end
 
     def test_placeholders_old_style


### PR DESCRIPTION
Sometimes it's necessary to specify file extensions explicitly.
Added `extension` config param.