### PR TITLE
I modified it to find a name that can be used when using two or more standby names.

### DIFF
--- a/lib/fluent/plugin/out_webhdfs.rb
+++ b/lib/fluent/plugin/out_webhdfs.rb
@@ -300,11 +300,9 @@ class Fluent::Plugin::WebHDFSOutput < Fluent::Plugin::Output
   end
 
   def namenode_replace_to_standby(index)
-    if @clients_standby
-      @client_ha_index = index
-      @client = @clients_standby[@client_ha_index]
-      log.warn "Namenode failovered, now using #{@client.host}:#{@client.port}."
-    end
+    @client_ha_index = index
+    @client = @clients_standby[@client_ha_index]
+    log.warn "Namenode failovered, now using #{@client.host}:#{@client.port}."
   end
 
   def send_data(path, data)


### PR DESCRIPTION
Hello, I'm Lion2me.

I am using one active namenode and two standby namenodes using the zookeeper.

While using the webhdfs plug-in, I saw that the number of standby names was fixed to one, and I am sending the corrections I made to apply to the current environment as PR.

The major changes are as follows:

1. Standby nameenode was made to receive multiple values based on the space.
2. In order to switch the nameenode, clients_standby were arranged and modified to access the index.
3. When failover occurred, clients_standby was iterated to find and switch available namesenodes.