### PR TITLE
Implement delegation token max lifetime option

### DIFF
--- a/fluent-plugin-webhdfs.gemspec
+++ b/fluent-plugin-webhdfs.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bzip2-ffi"
   gem.add_development_dependency "zstandard"
   gem.add_runtime_dependency "fluentd", '>= 0.14.22'
-  gem.add_runtime_dependency "webhdfs", '>= 0.10.0'
+  gem.add_runtime_dependency "webhdfs", '>= 0.11.0'
 end

--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -403,6 +403,7 @@ class WebHDFSOutputTest < Test::Unit::TestCase
           renew_kerberos_delegation_token: d.instance.instance_eval("@renew_kerberos_delegation_token"),
           renew_kerberos_delegation_token_interval: d.instance.instance_eval("@renew_kerberos_delegation_token_interval"),
           renew_kerberos_delegation_token_interval_hour: d.instance.instance_eval("@renew_kerberos_delegation_token_interval_hour"),
+          kerberos_delegation_token_max_lifetime: d.instance.instance_eval("@kerberos_delegation_token_max_lifetime"),
           kerberos_delegation_token_max_lifetime_hour: d.instance.instance_eval("@kerberos_delegation_token_max_lifetime_hour"),
         })
     end

--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -328,7 +328,7 @@ class WebHDFSOutputTest < Test::Unit::TestCase
       })
 
     test "renew_kerberos_delegation_token default" do
-      mock.proxy(WebHDFS::Client).new("server.local", 14000, "hdfs_user", nil, nil, nil, {}, nil).once
+      mock.proxy(WebHDFS::Client).new("server.local", 14000, "hdfs_user", nil, nil, nil, {}, nil, nil).once
 
       d = create_driver(CONFIG_KERBEROS)
 
@@ -350,7 +350,7 @@ class WebHDFSOutputTest < Test::Unit::TestCase
     test "default renew_kerberos_delegation_token_interval" do
       expected_hour = 8
       expected_delegation_token_max_lifetime_hour = 7 * 24
-      mock.proxy(WebHDFS::Client).new("server.local", 14000, "hdfs_user", nil, nil, nil, {}, expected_hour,nil).once
+      mock.proxy(WebHDFS::Client).new("server.local", 14000, "hdfs_user", nil, nil, nil, {}, expected_hour, expected_delegation_token_max_lifetime_hour).once
 
       d = create_driver(CONFIG_KERBEROS +
                         config_element("", "", { "renew_kerberos_delegation_token" => true }))
@@ -369,6 +369,7 @@ class WebHDFSOutputTest < Test::Unit::TestCase
           renew_kerberos_delegation_token: d.instance.instance_eval("@renew_kerberos_delegation_token"),
           renew_kerberos_delegation_token_interval: d.instance.instance_eval("@renew_kerberos_delegation_token_interval"),
           renew_kerberos_delegation_token_interval_hour: d.instance.instance_eval("@renew_kerberos_delegation_token_interval_hour"),
+          kerberos_delegation_token_max_lifetime: d.instance.instance_eval("@kerberos_delegation_token_max_lifetime"),
           kerberos_delegation_token_max_lifetime_hour: d.instance.instance_eval("@kerberos_delegation_token_max_lifetime_hour"),
         })
     end

--- a/test/plugin/test_out_webhdfs.rb
+++ b/test/plugin/test_out_webhdfs.rb
@@ -337,18 +337,20 @@ class WebHDFSOutputTest < Test::Unit::TestCase
           kerberos: true,
           renew_kerberos_delegation_token: false,
           renew_kerberos_delegation_token_interval_hour: nil,
+          kerberos_delegation_token_max_lifetime_hour: nil,
         },
         {
           kerberos: d.instance.kerberos,
           renew_kerberos_delegation_token: d.instance.instance_eval("@renew_kerberos_delegation_token"),
           renew_kerberos_delegation_token_interval_hour: d.instance.instance_eval("@renew_kerberos_delegation_token_interval_hour"),
+          kerberos_delegation_token_max_lifetime_hour: d.instance.instance_eval("@kerberos_delegation_token_max_lifetime_hour"),
         })
     end
 
     test "default renew_kerberos_delegation_token_interval" do
       expected_hour = 8
-
-      mock.proxy(WebHDFS::Client).new("server.local", 14000, "hdfs_user", nil, nil, nil, {}, expected_hour).once
+      expected_delegation_token_max_lifetime_hour = 7 * 24
+      mock.proxy(WebHDFS::Client).new("server.local", 14000, "hdfs_user", nil, nil, nil, {}, expected_hour,nil).once
 
       d = create_driver(CONFIG_KERBEROS +
                         config_element("", "", { "renew_kerberos_delegation_token" => true }))
@@ -359,19 +361,23 @@ class WebHDFSOutputTest < Test::Unit::TestCase
           renew_kerberos_delegation_token: true,
           renew_kerberos_delegation_token_interval: expected_hour * 60 * 60,
           renew_kerberos_delegation_token_interval_hour: expected_hour,
+          kerberos_delegation_token_max_lifetime: expected_delegation_token_max_lifetime_hour * 60 * 60,
+          kerberos_delegation_token_max_lifetime_hour: expected_delegation_token_max_lifetime_hour,
         },
         {
           kerberos: d.instance.kerberos,
           renew_kerberos_delegation_token: d.instance.instance_eval("@renew_kerberos_delegation_token"),
           renew_kerberos_delegation_token_interval: d.instance.instance_eval("@renew_kerberos_delegation_token_interval"),
           renew_kerberos_delegation_token_interval_hour: d.instance.instance_eval("@renew_kerberos_delegation_token_interval_hour"),
+          kerberos_delegation_token_max_lifetime_hour: d.instance.instance_eval("@kerberos_delegation_token_max_lifetime_hour"),
         })
     end
 
     test "renew_kerberos_delegation_token_interval" do
       expected_hour = 10
+      expected_delegation_token_max_lifetime_hour = 24
 
-      mock.proxy(WebHDFS::Client).new("server.local", 14000, "hdfs_user", nil, nil, nil, {}, expected_hour).once
+      mock.proxy(WebHDFS::Client).new("server.local", 14000, "hdfs_user", nil, nil, nil, {}, expected_hour,expected_delegation_token_max_lifetime_hour).once
 
       d = create_driver(
         CONFIG_KERBEROS +
@@ -380,6 +386,7 @@ class WebHDFSOutputTest < Test::Unit::TestCase
           {
             "renew_kerberos_delegation_token" => true,
             "renew_kerberos_delegation_token_interval" => "#{expected_hour}h",
+            "kerberos_delegation_token_max_lifetime" => "#{expected_delegation_token_max_lifetime_hour}h"
           }))
 
       assert_equal(
@@ -388,12 +395,15 @@ class WebHDFSOutputTest < Test::Unit::TestCase
           renew_kerberos_delegation_token: true,
           renew_kerberos_delegation_token_interval: expected_hour * 60 * 60,
           renew_kerberos_delegation_token_interval_hour: expected_hour,
+          kerberos_delegation_token_max_lifetime: expected_delegation_token_max_lifetime_hour * 60 * 60,
+          kerberos_delegation_token_max_lifetime_hour: expected_delegation_token_max_lifetime_hour
         },
         {
           kerberos: d.instance.kerberos,
           renew_kerberos_delegation_token: d.instance.instance_eval("@renew_kerberos_delegation_token"),
           renew_kerberos_delegation_token_interval: d.instance.instance_eval("@renew_kerberos_delegation_token_interval"),
           renew_kerberos_delegation_token_interval_hour: d.instance.instance_eval("@renew_kerberos_delegation_token_interval_hour"),
+          kerberos_delegation_token_max_lifetime_hour: d.instance.instance_eval("@kerberos_delegation_token_max_lifetime_hour"),
         })
     end
 


### PR DESCRIPTION
I am using the function to renew delegation tokens.
However, if the max-lifetime setting is configured in Hadoop, the token can no longer be renewed and used, and a new token must be obtained.
This PR is the implementation of that functionality.
This PR is related to https://github.com/kzk/webhdfs/pull/45
